### PR TITLE
Fix icon on dark backgrounds

### DIFF
--- a/theme/icons/insert-footnote.svg
+++ b/theme/icons/insert-footnote.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
-  <text x="2" y="15" font-family="Arial, sans-serif" font-size="14" fill="black">ab</text>
-  <text x="17" y="10" font-family="Arial, sans-serif" font-size="8" fill="black">1</text>
+  <text x="2" y="15" font-family="Arial, sans-serif" font-size="14" fill="currentColor">ab</text>
+  <text x="17" y="10" font-family="Arial, sans-serif" font-size="8" fill="currentColor">1</text>
 </svg>


### PR DESCRIPTION
The icon had a hard-coded `black` color instead of `currentColor`. On themes with a darker background where the stroke is light, it makes the icon hard to read.

Before:

![image](https://github.com/user-attachments/assets/1fa08851-3606-4ae7-99a3-97be6a8efaec)

After:

![image](https://github.com/user-attachments/assets/e7e3b1a0-9fcf-4eb6-a5fb-d186bf7f6a0c)
